### PR TITLE
Customize Personal dbt Event Logging Project

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ on-run-start:
 
 on-run-end:
   - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
-  - "{{ logging.unload_to_s3( var('unload_to_s3', false) )}}"
+  - "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ on-run-start:
 
 on-run-end:
   - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
-  - "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
+  #- "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -16,13 +16,13 @@ clean-targets:
 
 
 on-run-start:
-  - "{{ logging.create_audit_schema() }}"
-  - "{{ logging.create_audit_log_table() }}"
-  - "{{ logging.log_run_start_event() }}"
+  - "{{ logging.create_audit_schema( var('run_dbt_logging', false)) }}"
+  - "{{ logging.create_audit_log_table( var('run_dbt_logging', false)) }}"
+  - "{{ logging.log_run_start_event( var('run_dbt_logging', false)) }}"
 
 
 on-run-end:
-  - "{{ logging.log_run_end_event() }}"
+  - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
   - "{{ logging.unload_to_s3( var('unload_to_s3', false) )}}"
 
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ on-run-start:
 
 on-run-end:
   - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
-  #- "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
+  - "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -16,14 +16,14 @@ clean-targets:
 
 
 on-run-start:
-  - "{%- if var('run_dbt_logging', false) -%} {{ logging.create_audit_schema( var('run_dbt_logging', false)) }} {%- endif -%}"
-  - "{%- if var('run_dbt_logging', false) -%} {{ logging.create_audit_log_table( var('run_dbt_logging', false)) }} {%- endif -%}"
-  - "{%- if var('run_dbt_logging', false) -%} {{ logging.log_run_start_event( var('run_dbt_logging', false)) }} {%- endif -%}"
+  - "{{ logging.create_audit_schema( var('run_dbt_logging', false)) }}"
+  - "{{ logging.create_audit_log_table( var('run_dbt_logging', false)) }}"
+  - "{{ logging.log_run_start_event( var('run_dbt_logging', false)) }}"
 
 
 on-run-end:
-  - "{%- if var('run_dbt_logging', false) -%} {{ logging.log_run_end_event( var('run_dbt_logging', false)) }} {%- endif -%}"
-  - "{%- if var('run_dbt_logging', false) -%} {{ logging.unload_to_s3( var('unload_to_s3', false) )}} {%- endif -%}"
+  - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
+  - "{{ logging.unload_to_s3( var('unload_to_s3', false) )}}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -16,14 +16,14 @@ clean-targets:
 
 
 on-run-start:
-  - "{{ logging.create_audit_schema( var('run_dbt_logging', false)) }}"
-  - "{{ logging.create_audit_log_table( var('run_dbt_logging', false)) }}"
-  - "{{ logging.log_run_start_event( var('run_dbt_logging', false)) }}"
+  - "{%- if var('run_dbt_logging', false) -%} {{ logging.create_audit_schema( var('run_dbt_logging', false)) }} {%- endif -%}"
+  - "{%- if var('run_dbt_logging', false) -%} {{ logging.create_audit_log_table( var('run_dbt_logging', false)) }} {%- endif -%}"
+  - "{%- if var('run_dbt_logging', false) -%} {{ logging.log_run_start_event( var('run_dbt_logging', false)) }} {%- endif -%}"
 
 
 on-run-end:
-  - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
-  - "{{ logging.unload_to_s3( var('unload_to_s3', false) )}}"
+  - "{%- if var('run_dbt_logging', false) -%} {{ logging.log_run_end_event( var('run_dbt_logging', false)) }} {%- endif -%}"
+  - "{%- if var('run_dbt_logging', false) -%} {{ logging.unload_to_s3( var('unload_to_s3', false) )}} {%- endif -%}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,8 +1,10 @@
 name: 'logging'
 version: '1.0'
 
+profile: 'default'
+
 source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
@@ -17,12 +19,13 @@ on-run-start:
   - "{{ logging.create_audit_schema() }}"
   - "{{ logging.create_audit_log_table() }}"
   - "{{ logging.log_run_start_event() }}"
-  
-  
+
+
 on-run-end:
   - "{{ logging.log_run_end_event() }}"
+  - "{{ logging.unload_to_s3( var('unload_to_s3', false) )}}"
 
 
 models:
-  logging:  
+  logging:
     schema: meta

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -1,8 +1,8 @@
 {% macro get_audit_relation() %}
-    {%- set audit_table = 
+    {%- set audit_table =
         api.Relation.create(
-            identifier='dbt_audit_log', 
-            schema=target.schema~'_meta', 
+            identifier='dbt_audit_log',
+            schema=target.schema~'_meta',
             type='table'
         ) -%}
     {{ return(audit_table) }}
@@ -11,25 +11,25 @@
 
 {% macro get_audit_schema() %}
     {% set audit_table = logging.get_audit_relation() %}
-    {{ return(audit_table.include(schema=True, identifier=False)) }}    
+    {{ return(audit_table.include(schema=True, identifier=False)) }}
 {% endmacro %}
 
 
 {% macro log_audit_event(event_name, schema, relation) %}
 
     insert into {{ logging.get_audit_relation() }} (
-        event_name, 
-        event_timestamp, 
-        event_schema, 
+        event_name,
+        event_timestamp,
+        event_schema,
         event_model,
         invocation_id
-        ) 
-    
+        )
+
     values (
-        '{{ event_name }}', 
-        {{dbt_utils.current_timestamp_in_utc()}}, 
-        {% if variable != None %}'{{ schema }}'{% else %}null::varchar(512){% endif %}, 
-        {% if variable != None %}'{{ relation }}'{% else %}null::varchar(512){% endif %}, 
+        '{{ event_name }}',
+        {{dbt_utils.current_timestamp_in_utc()}},
+        {% if variable != None %}'{{ schema }}'{% else %}null::varchar(512){% endif %},
+        {% if variable != None %}'{{ relation }}'{% else %}null::varchar(512){% endif %},
         '{{ invocation_id }}'
         )
 
@@ -76,4 +76,12 @@
     {{logging.log_audit_event(
         'model deployment completed', this.schema, this.name
         )}}
+{% endmacro %}
+
+{% macro unload_to_s3(unload_to_s3=False) %}
+  {% if unload_to_s3 %}
+    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
+  {% else %}
+    select 1
+  {% endif %}
 {% endmacro %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -95,7 +95,8 @@
 
 {% macro unload_to_s3(unload_to_s3=False) %}
   {% if unload_to_s3 %}
-    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite; commit; {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
+    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite
+    {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
   {% else %}
     select 1
   {% endif %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -36,13 +36,16 @@
 {% endmacro %}
 
 
-{% macro create_audit_schema() %}
+{% macro create_audit_schema(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     create schema if not exists {{ logging.get_audit_schema() }}
+  {% endif %}
 {% endmacro %}
 
 
-{% macro create_audit_log_table() %}
+{% macro create_audit_log_table(run_dbt_logging=False) %}
 
+  {% if run_dbt_logging %}
     create table if not exists {{ logging.get_audit_relation() }}
     (
        event_name       varchar(512),
@@ -51,31 +54,40 @@
        event_model      varchar(512),
        invocation_id    varchar(512)
     )
+  {% endif %}
 
 {% endmacro %}
 
 
-{% macro log_run_start_event() %}
+{% macro log_run_start_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event('run started')}}
+  {% endif %}
 {% endmacro %}
 
 
-{% macro log_run_end_event() %}
+{% macro log_run_end_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event('run completed')}}; commit;
+  {% endif %}
 {% endmacro %}
 
 
-{% macro log_model_start_event() %}
+{% macro log_model_start_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event(
         'model deployment started', this.schema, this.name
         )}}
+  {% endif %}
 {% endmacro %}
 
 
-{% macro log_model_end_event() %}
+{% macro log_model_end_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event(
         'model deployment completed', this.schema, this.name
         )}}
+  {% endif %}
 {% endmacro %}
 
 {% macro unload_to_s3(unload_to_s3=False) %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -96,7 +96,6 @@
 {% macro unload_to_s3(unload_to_s3=False) %}
   {% if unload_to_s3 %}
     unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite
-    {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
   {% else %}
     select 1
   {% endif %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -2,7 +2,7 @@
     {%- set audit_table =
         api.Relation.create(
             identifier='dbt_audit_log',
-            schema=target.schema~'_meta',
+            schema=target.schema~'_invocations',
             type='table'
         ) -%}
     {{ return(audit_table) }}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -95,7 +95,7 @@
 
 {% macro unload_to_s3(unload_to_s3=False) %}
   {% if unload_to_s3 %}
-    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite
+    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ var('dbt_iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite
   {% else %}
     select 1
   {% endif %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -73,7 +73,7 @@
 
 {% macro log_run_end_event(run_dbt_logging=False) %}
   {% if run_dbt_logging %}
-    {{logging.log_audit_event('run completed')}}; commit;
+    {{logging.log_audit_event('run completed')}}
   {% else %}
     select 1
   {% endif %}
@@ -95,7 +95,7 @@
 
 {% macro unload_to_s3(unload_to_s3=False) %}
   {% if unload_to_s3 %}
-    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
+    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ env_var('DBT_IAM_ROLE') }}' manifest delimiter as ',' null as '' escape allowoverwrite; commit; {{log(modules.datetime.datetime.now().strftime('%H:%M:%S') ~ ' | Unload to s3 requested for dbt invocation logs.', info=True)}}
   {% else %}
     select 1
   {% endif %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -36,13 +36,17 @@
 {% endmacro %}
 
 
-{% macro create_audit_schema() %}
+{% macro create_audit_schema(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     create schema if not exists {{ logging.get_audit_schema() }}
+  {% else %}
+    select 1
+  {% endif %}
 {% endmacro %}
 
 
-{% macro create_audit_log_table() %}
-
+{% macro create_audit_log_table(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     create table if not exists {{ logging.get_audit_relation() }}
     (
        event_name       varchar(512),
@@ -51,17 +55,28 @@
        event_model      varchar(512),
        invocation_id    varchar(512)
     )
+  {% else %}
+    select 1
+  {% endif %}
 
 {% endmacro %}
 
 
-{% macro log_run_start_event() %}
+{% macro log_run_start_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event('run started')}}
+  {% else %}
+    select 1
+  {% endif %}
 {% endmacro %}
 
 
-{% macro log_run_end_event() %}
+{% macro log_run_end_event(run_dbt_logging=False) %}
+  {% if run_dbt_logging %}
     {{logging.log_audit_event('run completed')}}; commit;
+  {% else %}
+    select 1
+  {% endif %}
 {% endmacro %}
 
 

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -36,16 +36,13 @@
 {% endmacro %}
 
 
-{% macro create_audit_schema(run_dbt_logging=False) %}
-  {% if run_dbt_logging %}
+{% macro create_audit_schema() %}
     create schema if not exists {{ logging.get_audit_schema() }}
-  {% endif %}
 {% endmacro %}
 
 
-{% macro create_audit_log_table(run_dbt_logging=False) %}
+{% macro create_audit_log_table() %}
 
-  {% if run_dbt_logging %}
     create table if not exists {{ logging.get_audit_relation() }}
     (
        event_name       varchar(512),
@@ -54,40 +51,31 @@
        event_model      varchar(512),
        invocation_id    varchar(512)
     )
-  {% endif %}
 
 {% endmacro %}
 
 
-{% macro log_run_start_event(run_dbt_logging=False) %}
-  {% if run_dbt_logging %}
+{% macro log_run_start_event() %}
     {{logging.log_audit_event('run started')}}
-  {% endif %}
 {% endmacro %}
 
 
-{% macro log_run_end_event(run_dbt_logging=False) %}
-  {% if run_dbt_logging %}
+{% macro log_run_end_event() %}
     {{logging.log_audit_event('run completed')}}; commit;
-  {% endif %}
 {% endmacro %}
 
 
-{% macro log_model_start_event(run_dbt_logging=False) %}
-  {% if run_dbt_logging %}
+{% macro log_model_start_event() %}
     {{logging.log_audit_event(
         'model deployment started', this.schema, this.name
         )}}
-  {% endif %}
 {% endmacro %}
 
 
-{% macro log_model_end_event(run_dbt_logging=False) %}
-  {% if run_dbt_logging %}
+{% macro log_model_end_event() %}
     {{logging.log_audit_event(
         'model deployment completed', this.schema, this.name
         )}}
-  {% endif %}
 {% endmacro %}
 
 {% macro unload_to_s3(unload_to_s3=False) %}


### PR DESCRIPTION
This PR implements a few customizations that iterates on Fishtown's [dbt-event-logging package](https://github.com/fishtown-analytics/dbt-event-logging) to make it more custom and specific to our needs. These changes include:
1. Make model logging **optional.**
2. Rename logging schema from `_meta` to `_invocations` for clarity.
3. Point dbt-utils package to `master` revision to prevent revision conflicts.
4. Add in `unload_to_s3` macro for unloading logs.