### PR TITLE
Prevent Unload From Attempting to Unload Non-Existent Schema

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ on-run-start:
 
 on-run-end:
   - "{{ logging.log_run_end_event( var('run_dbt_logging', false)) }}"
-  - "{{ logging.unload_to_s3( var('unload_to_s3', false)) }}"
+  - "{{ logging.unload_to_s3(run_dbt_logging=var('run_dbt_logging', false), unload_to_s3=var('unload_to_s3', false)) }}"
 
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,4 +28,3 @@ on-run-end:
 
 models:
   logging:
-    schema: meta

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -93,12 +93,14 @@
         )}}
 {% endmacro %}
 
-{% macro unload_to_s3(unload_to_s3=False) %}
+{% macro unload_to_s3(run_dbt_logging=False, unload_to_s3=False) %}
 
-  {% if unload_to_s3 %}
-    {{ logging.create_audit_schema(run_dbt_logging=True) }};
-    {{ logging.create_audit_log_table(run_dbt_logging=True) }};
-    unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ var('dbt_iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite
+  {% if run_dbt_logging %}
+    {% if unload_to_s3 %}
+      unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ var('dbt_iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite
+    {% else %}
+      select 1
+    {% endif %}
   {% else %}
     select 1
   {% endif %}

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -94,7 +94,10 @@
 {% endmacro %}
 
 {% macro unload_to_s3(unload_to_s3=False) %}
+
   {% if unload_to_s3 %}
+    {{ logging.create_audit_schema(run_dbt_logging=True) }}
+    {{ logging.create_audit_log_table(run_dbt_logging=True) }}
     unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ var('dbt_iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite
   {% else %}
     select 1

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -96,8 +96,8 @@
 {% macro unload_to_s3(unload_to_s3=False) %}
 
   {% if unload_to_s3 %}
-    {{ logging.create_audit_schema(run_dbt_logging=True) }}
-    {{ logging.create_audit_log_table(run_dbt_logging=True) }}
+    {{ logging.create_audit_schema(run_dbt_logging=True) }};
+    {{ logging.create_audit_log_table(run_dbt_logging=True) }};
     unload ('select dil.* from dbt_spectrum_redshift.dbt_invocation_logs dil union select d.* from {{ logging.get_audit_relation() }} d') to 's3://redshift-dbt-logs/dbt_invocation_logs/dbt_invocation_logs_' iam_role '{{ var('dbt_iam_role') }}' manifest delimiter as ',' null as '' escape allowoverwrite
   {% else %}
     select 1


### PR DESCRIPTION
This PR fixes the `unload_to_s3` macro in our custom implementation of the dbt-event-logging package. Currently, if you set the `unload_to_s3` variable to `True` without running dbt logging and without the schemas/tables already built in the warehouse, the unload will fail and the dbt run will error. This prevents that from happening by ensuring unloads only occur when logs are actually run.